### PR TITLE
fix: 修正QuizHeading的CSS，避免手機版跑版

### DIFF
--- a/components/Quiz.tsx
+++ b/components/Quiz.tsx
@@ -79,8 +79,8 @@ function Quiz({ children }: PropsWithChildren) {
       <UserAnswerContext.Provider value={{ userAnswer, setUserAnswer }}>
         <IsSubmitContext.Provider value={isSubmit}>
           <div
-            className="answer-list bg-[#fafafa] border border-[#eaeaea]
-            rounded-lg p-4 pt-0 mt-8 mb-16">
+            className="mdx-component answer-list bg-[#fafafa]
+            border border-[#eaeaea] rounded-lg p-4 pt-0 mt-8 mb-16">
             {children}
             <div className="mt-8">
               {isSubmit
@@ -98,7 +98,7 @@ function QuizHeading(
   { type, children }: PropsWithChildren<QuizHeadingProps>
 ) {
   return (
-    <div className="flex items-center">
+    <div className="[&_p]:inline my-4">
       <strong>{type}：</strong>
       {children}
     </div>


### PR DESCRIPTION
fix: 修正QuizHeading的CSS，避免手機版跑版

|  修改前   | 修改後  |
|  ----  | ----  |
| <img width="307" alt="image" src="https://user-images.githubusercontent.com/80741494/191279309-64184697-b75e-49f5-a0d8-34a9d43370d0.png">  | <img width="387" alt="image" src="https://user-images.githubusercontent.com/80741494/191278832-116855ac-3063-4498-aa7f-f1df3ab17d5d.png"> |

