### PR TITLE
feat: Add Table component.

### DIFF
--- a/components/MDXComponents/Table/Table.tsx
+++ b/components/MDXComponents/Table/Table.tsx
@@ -1,0 +1,63 @@
+import type { FC } from 'react';
+
+export const MDXTable: FC<
+  JSX.IntrinsicElements['table']
+  > = ({ children, ...rest }: JSX.IntrinsicElements['table']) => {
+    return (
+      <table
+        {...rest}
+        className="table-auto border-collapse w-full my-5">
+        {children}
+      </table>
+    );
+  };
+
+export const MDXThead: FC<
+  JSX.IntrinsicElements['thead']
+  > = ({ children, ...rest }: JSX.IntrinsicElements['thead']) => {
+    return (
+      <thead {...rest} className="p-2 border">
+        {children}
+      </thead>
+    );
+  };
+
+export const MDXBody: FC<
+  JSX.IntrinsicElements['tbody']
+  > = ({ children, ...rest }: JSX.IntrinsicElements['tbody']) => {
+    return (
+      <tbody {...rest} className="p-2">
+        {children}
+      </tbody>
+    );
+  };
+
+export const MDXTr: FC<
+  JSX.IntrinsicElements['tr']
+  > = ({ children, ...rest }: JSX.IntrinsicElements['tr']) => {
+    return (
+      <tr {...rest} className="p-2 border-y">
+        {children}
+      </tr>
+    );
+  };
+
+export const MDXTh: FC<
+  JSX.IntrinsicElements['th']
+  > = ({ children, ...rest }: JSX.IntrinsicElements['th']) => {
+    return (
+      <th {...rest} className="p-2 text-start">
+        {children}
+      </th>
+    );
+  };
+
+export const MDXTd: FC<
+  JSX.IntrinsicElements['td']
+  > = ({ children, ...rest }: JSX.IntrinsicElements['td']) => {
+    return (
+      <td {...rest} className="p-2">
+        {children}
+      </td>
+    );
+  };

--- a/components/MDXComponents/Table/Table.tsx
+++ b/components/MDXComponents/Table/Table.tsx
@@ -1,8 +1,15 @@
-import type { FC } from 'react';
+import type {
+  DetailedHTMLProps,
+  FC,
+  HTMLAttributes,
+  TableHTMLAttributes,
+  TdHTMLAttributes,
+  ThHTMLAttributes
+} from 'react';
 
 export const MDXTable: FC<
-  JSX.IntrinsicElements['table']
-  > = ({ children, ...rest }: JSX.IntrinsicElements['table']) => {
+    DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement>
+  > = ({ children, ...rest }) => {
     return (
       <table
         {...rest}
@@ -13,8 +20,10 @@ export const MDXTable: FC<
   };
 
 export const MDXThead: FC<
-  JSX.IntrinsicElements['thead']
-  > = ({ children, ...rest }: JSX.IntrinsicElements['thead']) => {
+    DetailedHTMLProps<
+        HTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement
+      >
+  > = ({ children, ...rest }) => {
     return (
       <thead {...rest} className="p-2 border">
         {children}
@@ -22,9 +31,11 @@ export const MDXThead: FC<
     );
   };
 
-export const MDXBody: FC<
-  JSX.IntrinsicElements['tbody']
-  > = ({ children, ...rest }: JSX.IntrinsicElements['tbody']) => {
+export const MDXTBody: FC<
+    DetailedHTMLProps<
+        TableHTMLAttributes<HTMLTableSectionElement>, HTMLTableSectionElement
+      >
+  > = ({ children, ...rest }) => {
     return (
       <tbody {...rest} className="p-2">
         {children}
@@ -33,8 +44,8 @@ export const MDXBody: FC<
   };
 
 export const MDXTr: FC<
-  JSX.IntrinsicElements['tr']
-  > = ({ children, ...rest }: JSX.IntrinsicElements['tr']) => {
+    DetailedHTMLProps<HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement>
+  > = ({ children, ...rest }) => {
     return (
       <tr {...rest} className="p-2 border-y">
         {children}
@@ -43,8 +54,10 @@ export const MDXTr: FC<
   };
 
 export const MDXTh: FC<
-  JSX.IntrinsicElements['th']
-  > = ({ children, ...rest }: JSX.IntrinsicElements['th']) => {
+    DetailedHTMLProps<
+        ThHTMLAttributes<HTMLTableHeaderCellElement>, HTMLTableHeaderCellElement
+      >
+  > = ({ children, ...rest }) => {
     return (
       <th {...rest} className="p-2 text-start">
         {children}
@@ -53,7 +66,9 @@ export const MDXTh: FC<
   };
 
 export const MDXTd: FC<
-  JSX.IntrinsicElements['td']
+    DetailedHTMLProps<
+        TdHTMLAttributes<HTMLTableDataCellElement>, HTMLTableDataCellElement
+      >
   > = ({ children, ...rest }: JSX.IntrinsicElements['td']) => {
     return (
       <td {...rest} className="p-2">

--- a/components/MDXComponents/Table/index.ts
+++ b/components/MDXComponents/Table/index.ts
@@ -1,0 +1,1 @@
+export * from './Table';

--- a/components/MDXComponents/index.ts
+++ b/components/MDXComponents/index.ts
@@ -1,0 +1,8 @@
+export {
+  MDXTable as table,
+  MDXTh as th,
+  MDXTd as td,
+  MDXThead as thead,
+  MDXBody as tbody,
+  MDXTr as tr,
+} from './Table';

--- a/components/MDXComponents/index.ts
+++ b/components/MDXComponents/index.ts
@@ -3,6 +3,6 @@ export {
   MDXTh as th,
   MDXTd as td,
   MDXThead as thead,
-  MDXBody as tbody,
+  MDXTBody as tbody,
   MDXTr as tr,
 } from './Table';

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,14 @@
-const withMDX = require('@next/mdx')({
+import nextMDX from '@next/mdx';
+import remarkFrontmatter from 'remark-frontmatter';
+import remarkGfm from 'remark-gfm';
+
+const withMDX = nextMDX({
   extension: /\.mdx?$/,
   options: {
-    remarkPlugins: [require('./compiled/remark-frontmatter').remarkFrontmatter],
+    remarkPlugins: [
+      remarkFrontmatter,
+      remarkGfm
+    ],
     rehypePlugins: [],
     providerImportSource: "@mdx-js/react"
   }
@@ -14,4 +21,4 @@ const nextConfig = {
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx']
 }
 
-module.exports = withMDX(nextConfig);
+export default withMDX(nextConfig);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-syntax-highlighter": "^15.5.0",
+    "remark-frontmatter": "^4.0.1",
+    "remark-gfm": "^3.0.1",
     "scroll-lock": "^2.1.5"
   },
   "devDependencies": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,7 +5,8 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import CodeStyle from 'react-syntax-highlighter/dist/cjs/styles/prism/atom-dark';
 import TranslatedBy from '@components/TranslatedBy';
 import Pagination from '@components/Pagination';
-import Card from '@components/Card'
+import Card from '@components/Card';
+import * as MDXComponents from '@components/MDXComponents';
 import type { AppProps } from 'next/app';
 
 const mdxComponents = {
@@ -29,6 +30,7 @@ const mdxComponents = {
   >
     {props.children}
   </blockquote>,
+  ...MDXComponents,
 };
 
 function MyApp({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,8 @@ specifiers:
   react: 18.2.0
   react-dom: 18.2.0
   react-syntax-highlighter: ^15.5.0
+  remark-frontmatter: ^4.0.1
+  remark-gfm: ^3.0.1
   scroll-lock: ^2.1.5
   tailwindcss: ^3.1.8
   typescript: 4.8.2
@@ -33,6 +35,8 @@ dependencies:
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
   react-syntax-highlighter: 15.5.0_react@18.2.0
+  remark-frontmatter: 4.0.1
+  remark-gfm: 3.0.1
   scroll-lock: 2.1.5
 
 devDependencies:
@@ -49,7 +53,7 @@ devDependencies:
   eslint-plugin-import: 2.26.0_pwovp45kjytedpuwpq6ialv6fq
   eslint-plugin-react: 7.31.1_eslint@8.22.0
   postcss: 8.4.16
-  tailwindcss: 3.1.8
+  tailwindcss: 3.1.8_postcss@8.4.16
   typescript: 4.8.2
 
 packages:
@@ -1010,6 +1014,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /escape-string-regexp/5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+    dev: false
+
   /eslint-config-next/12.2.5_shit3uhl6a7megkzgoz6xssnfa:
     resolution: {integrity: sha512-SOowilkqPzW6DxKp3a3SYlrfPi5Ajs9MIzp9gVfUDxxH9QFM5ElkR1hX5m/iICJuvCbWgQqFBiA3mCMozluniw==}
     peerDependencies:
@@ -1431,6 +1440,12 @@ packages:
 
   /fault/1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
+    dependencies:
+      format: 0.2.2
+    dev: false
+
+  /fault/2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
     dependencies:
       format: 0.2.2
     dev: false
@@ -1968,12 +1983,24 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /markdown-table/3.0.2:
+    resolution: {integrity: sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA==}
+    dev: false
+
   /mdast-util-definitions/5.1.1:
     resolution: {integrity: sha512-rQ+Gv7mHttxHOBx2dkF4HWTg+EE+UR78ptQWDylzPKaQuVGdG4HIoY3SrS/pCp80nZ04greFvXbVFHT+uf0JVQ==}
     dependencies:
       '@types/mdast': 3.0.10
       '@types/unist': 2.0.6
       unist-util-visit: 4.1.1
+    dev: false
+
+  /mdast-util-find-and-replace/2.2.1:
+    resolution: {integrity: sha512-SobxkQXFAdd4b5WmEakmkVoh18icjQRxGy5OWTCzgsLRm1Fu/KCtwD1HIQSsmq5ZRjVH0Ehwg6/Fn3xIUk+nKw==}
+    dependencies:
+      escape-string-regexp: 5.0.0
+      unist-util-is: 5.1.1
+      unist-util-visit-parents: 5.1.1
     dev: false
 
   /mdast-util-from-markdown/1.2.0:
@@ -1991,6 +2018,68 @@ packages:
       micromark-util-types: 1.0.2
       unist-util-stringify-position: 3.0.2
       uvu: 0.5.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-frontmatter/1.0.0:
+    resolution: {integrity: sha512-7itKvp0arEVNpCktOET/eLFAYaZ+0cNjVtFtIPxgQ5tV+3i+D4SDDTjTzPWl44LT59PC+xdx+glNTawBdF98Mw==}
+    dependencies:
+      micromark-extension-frontmatter: 1.0.0
+    dev: false
+
+  /mdast-util-gfm-autolink-literal/1.0.2:
+    resolution: {integrity: sha512-FzopkOd4xTTBeGXhXSBU0OCDDh5lUj2rd+HQqG92Ld+jL4lpUfgX2AT2OHAVP9aEeDKp7G92fuooSZcYJA3cRg==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      ccount: 2.0.1
+      mdast-util-find-and-replace: 2.2.1
+      micromark-util-character: 1.1.0
+    dev: false
+
+  /mdast-util-gfm-footnote/1.0.1:
+    resolution: {integrity: sha512-p+PrYlkw9DeCRkTVw1duWqPRHX6Ywh2BNKJQcZbCwAuP/59B0Lk9kakuAd7KbQprVO4GzdW8eS5++A9PUSqIyw==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-to-markdown: 1.3.0
+      micromark-util-normalize-identifier: 1.0.0
+    dev: false
+
+  /mdast-util-gfm-strikethrough/1.0.1:
+    resolution: {integrity: sha512-zKJbEPe+JP6EUv0mZ0tQUyLQOC+FADt0bARldONot/nefuISkaZFlmVK4tU6JgfyZGrky02m/I6PmehgAgZgqg==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-to-markdown: 1.3.0
+    dev: false
+
+  /mdast-util-gfm-table/1.0.6:
+    resolution: {integrity: sha512-uHR+fqFq3IvB3Rd4+kzXW8dmpxUhvgCQZep6KdjsLK4O6meK5dYZEayLtIxNus1XO3gfjfcIFe8a7L0HZRGgag==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      markdown-table: 3.0.2
+      mdast-util-from-markdown: 1.2.0
+      mdast-util-to-markdown: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-gfm-task-list-item/1.0.1:
+    resolution: {integrity: sha512-KZ4KLmPdABXOsfnM6JHUIjxEvcx2ulk656Z/4Balw071/5qgnhz+H1uGtf2zIGnrnvDC8xR4Fj9uKbjAFGNIeA==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-to-markdown: 1.3.0
+    dev: false
+
+  /mdast-util-gfm/2.0.1:
+    resolution: {integrity: sha512-42yHBbfWIFisaAfV1eixlabbsa6q7vHeSPY+cg+BBjX51M8xhgMacqH9g6TftB/9+YkcI0ooV4ncfrJslzm/RQ==}
+    dependencies:
+      mdast-util-from-markdown: 1.2.0
+      mdast-util-gfm-autolink-literal: 1.0.2
+      mdast-util-gfm-footnote: 1.0.1
+      mdast-util-gfm-strikethrough: 1.0.1
+      mdast-util-gfm-table: 1.0.6
+      mdast-util-gfm-task-list-item: 1.0.1
+      mdast-util-to-markdown: 1.3.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2104,6 +2193,87 @@ packages:
       micromark-util-symbol: 1.0.1
       micromark-util-types: 1.0.2
       uvu: 0.5.6
+    dev: false
+
+  /micromark-extension-frontmatter/1.0.0:
+    resolution: {integrity: sha512-EXjmRnupoX6yYuUJSQhrQ9ggK0iQtQlpi6xeJzVD5xscyAI+giqco5fdymayZhJMbIFecjnE2yz85S9NzIgQpg==}
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+    dev: false
+
+  /micromark-extension-gfm-autolink-literal/1.0.3:
+    resolution: {integrity: sha512-i3dmvU0htawfWED8aHMMAzAVp/F0Z+0bPh3YrbTPPL1v4YAlCZpy5rBO5p0LPYiZo0zFVkoYh7vDU7yQSiCMjg==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-sanitize-uri: 1.0.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-extension-gfm-footnote/1.0.4:
+    resolution: {integrity: sha512-E/fmPmDqLiMUP8mLJ8NbJWJ4bTw6tS+FEQS8CcuDtZpILuOb2kjLqPEeAePF1djXROHXChM/wPJw0iS4kHCcIg==}
+    dependencies:
+      micromark-core-commonmark: 1.0.6
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-normalize-identifier: 1.0.0
+      micromark-util-sanitize-uri: 1.0.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-extension-gfm-strikethrough/1.0.4:
+    resolution: {integrity: sha512-/vjHU/lalmjZCT5xt7CcHVJGq8sYRm80z24qAKXzaHzem/xsDYb2yLL+NNVbYvmpLx3O7SYPuGL5pzusL9CLIQ==}
+    dependencies:
+      micromark-util-chunked: 1.0.0
+      micromark-util-classify-character: 1.0.0
+      micromark-util-resolve-all: 1.0.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-extension-gfm-table/1.0.5:
+    resolution: {integrity: sha512-xAZ8J1X9W9K3JTJTUL7G6wSKhp2ZYHrFk5qJgY/4B33scJzE2kpfRL6oiw/veJTbt7jiM/1rngLlOKPWr1G+vg==}
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-extension-gfm-tagfilter/1.0.1:
+    resolution: {integrity: sha512-Ty6psLAcAjboRa/UKUbbUcwjVAv5plxmpUTy2XC/3nJFL37eHej8jrHrRzkqcpipJliuBH30DTs7+3wqNcQUVA==}
+    dependencies:
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-extension-gfm-task-list-item/1.0.3:
+    resolution: {integrity: sha512-PpysK2S1Q/5VXi72IIapbi/jliaiOFzv7THH4amwXeYXLq3l1uo8/2Be0Ac1rEwK20MQEsGH2ltAZLNY2KI/0Q==}
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.6
+    dev: false
+
+  /micromark-extension-gfm/2.0.1:
+    resolution: {integrity: sha512-p2sGjajLa0iYiGQdT0oelahRYtMWvLjy8J9LOCxzIQsllMCGLbsLW+Nc+N4vi02jcRJvedVJ68cjelKIO6bpDA==}
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 1.0.3
+      micromark-extension-gfm-footnote: 1.0.4
+      micromark-extension-gfm-strikethrough: 1.0.4
+      micromark-extension-gfm-table: 1.0.5
+      micromark-extension-gfm-tagfilter: 1.0.1
+      micromark-extension-gfm-task-list-item: 1.0.3
+      micromark-util-combine-extensions: 1.0.0
+      micromark-util-types: 1.0.2
     dev: false
 
   /micromark-extension-mdx-expression/1.0.3:
@@ -2814,6 +2984,26 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /remark-frontmatter/4.0.1:
+    resolution: {integrity: sha512-38fJrB0KnmD3E33a5jZC/5+gGAC2WKNiPw1/fdXJvijBlhA7RCsvJklrYJakS0HedninvaCYW8lQGf9C918GfA==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-frontmatter: 1.0.0
+      micromark-extension-frontmatter: 1.0.0
+      unified: 10.1.2
+    dev: false
+
+  /remark-gfm/3.0.1:
+    resolution: {integrity: sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-gfm: 2.0.1
+      micromark-extension-gfm: 2.0.1
+      unified: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /remark-mdx/2.1.3:
     resolution: {integrity: sha512-3SmtXOy9+jIaVctL8Cs3VAQInjRLGOwNXfrBB9KCT+EpJpKD3PQiy0x8hUNGyjQmdyOs40BqgPU7kYtH9uoR6w==}
     dependencies:
@@ -3042,10 +3232,12 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /tailwindcss/3.1.8:
+  /tailwindcss/3.1.8_postcss@8.4.16:
     resolution: {integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==}
     engines: {node: '>=12.13.0'}
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3


### PR DESCRIPTION
## Change

 - 把 `next.config.js` 重新命名 `next.config.mjs` 以使用 ES Module 的方式導入 `remarkPlugins` 
 - 新增 `remark-gfm` 去編譯 Markdown 的 table 語法
 - 新增 `MDXComponents` 資料夾

### Before Change

![before-result](https://raw.githubusercontent.com/Chia1104/image/main/nextjs.tw/before-result.PNG)

![before-code](https://raw.githubusercontent.com/Chia1104/image/main/nextjs.tw/before-code.PNG)

### After Change

![after-result](https://raw.githubusercontent.com/Chia1104/image/main/nextjs.tw/after-result.PNG)

![after-code](https://raw.githubusercontent.com/Chia1104/image/main/nextjs.tw/after-code.PNG)

### Structure Change

```
components
└── MDXComponents
    ├── Table
    │    ├── Table.tsx
    │    └── index.ts  
    └── index.ts
```

## MDXComponents props type

```typescript
export const MDXTable: FC<
    DetailedHTMLProps<TableHTMLAttributes<HTMLTableElement>, HTMLTableElement>
  > = ({ children, ...rest }) => {
    return (
      <table
        {...rest}
        className="table-auto border-collapse w-full my-5">
        {children}
      </table>
    );
  };
```

這是 `@mdx-js/react` 中 `MDXProvider` 的 `components` type

```typescript
/**
 * MDX components may be passed as the `components`.
 *
 * The key is the name of the element to override. The value is the component to render instead.
 */
export type MDXComponents = NestedMDXComponents & {
    [Key in keyof JSX.IntrinsicElements]?: Component<JSX.IntrinsicElements[Key]> | keyof JSX.IntrinsicElements;
} & {
    /**
     * If a wrapper component is defined, the MDX content will be wrapped inside of it.
     */
    wrapper?: Component<any>;
};
```

當中的 `JSX.IntrinsicElements[Key]` 對應的 interface 可以參考 [這裡](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L3140)