### PR TITLE
fix: corrected Invalid `<Link>` with `<a>` child

### DIFF
--- a/pages/docs/advanced-features/i18n-routing.mdx
+++ b/pages/docs/advanced-features/i18n-routing.mdx
@@ -228,7 +228,7 @@ import Link from 'next/link'
 
 export default function IndexPage(props) {
   return (
-    <Link href="/another" locale="fr">
+    <Link href="/another" locale="fr" legacyBehavior>
       <a>To /fr/another</a>
     </Link>
   )
@@ -274,7 +274,7 @@ import Link from 'next/link'
 
 export default function IndexPage(props) {
   return (
-    <Link href="/fr/another" locale={false}>
+    <Link href="/fr/another" locale={false} legacyBehavior>
       <a>To /fr/another</a>
     </Link>
   )

--- a/pages/docs/advanced-features/i18n-routing.mdx
+++ b/pages/docs/advanced-features/i18n-routing.mdx
@@ -228,8 +228,8 @@ import Link from 'next/link'
 
 export default function IndexPage(props) {
   return (
-    <Link href="/another" locale="fr" legacyBehavior>
-      <a>To /fr/another</a>
+    <Link href="/another" locale="fr">
+      To /fr/another
     </Link>
   )
 }
@@ -274,8 +274,8 @@ import Link from 'next/link'
 
 export default function IndexPage(props) {
   return (
-    <Link href="/fr/another" locale={false} legacyBehavior>
-      <a>To /fr/another</a>
+    <Link href="/fr/another" locale={false}>
+      To /fr/another
     </Link>
   )
 }

--- a/pages/docs/api-reference/next.config.js/basepath.mdx
+++ b/pages/docs/api-reference/next.config.js/basepath.mdx
@@ -35,8 +35,8 @@ For example, using `/about` will automatically become `/docs/about` when `basePa
 export default function HomePage() {
   return (
     <>
-      <Link href="/about" legacyBehavior>
-        <a>About Page</a>
+      <Link href="/about">
+        bout Page
       </Link>
     </>
   )

--- a/pages/docs/api-reference/next.config.js/basepath.mdx
+++ b/pages/docs/api-reference/next.config.js/basepath.mdx
@@ -35,7 +35,7 @@ For example, using `/about` will automatically become `/docs/about` when `basePa
 export default function HomePage() {
   return (
     <>
-      <Link href="/about">
+      <Link href="/about" legacyBehavior>
         <a>About Page</a>
       </Link>
     </>

--- a/pages/docs/api-reference/next.config.js/basepath.mdx
+++ b/pages/docs/api-reference/next.config.js/basepath.mdx
@@ -36,7 +36,7 @@ export default function HomePage() {
   return (
     <>
       <Link href="/about">
-        bout Page
+        About Page
       </Link>
     </>
   )

--- a/pages/docs/api-reference/next/link.mdx
+++ b/pages/docs/api-reference/next/link.mdx
@@ -31,18 +31,18 @@ function Home() {
   return (
     <ul>
       <li>
-        <Link href="/" legacyBehavior>
-          <a>Home</a>
+        <Link href="/">
+          Home
         </Link>
       </li>
       <li>
-        <Link href="/about" legacyBehavior>
-          <a>About Us</a>
+        <Link href="/about">
+          About Us
         </Link>
       </li>
       <li>
-        <Link href="/blog/hello-world" legacyBehavior>
-          <a>Blog Post</a>
+        <Link href="/blog/hello-world">
+          Blog Post
         </Link>
       </li>
     </ul>
@@ -77,8 +77,8 @@ function Posts({ posts }) {
     <ul>
       {posts.map((post) => (
         <li key={post.id}>
-          <Link href={`/blog/${encodeURIComponent(post.slug)}`} legacyBehavior>
-            <a>{post.title}</a>
+          <Link href={`/blog/${encodeURIComponent(post.slug)}`}>
+            {post.title}
           </Link>
         </li>
       ))}
@@ -161,9 +161,8 @@ function Home() {
             pathname: '/about',
             query: { name: 'test' },
           }}
-          legacyBehavior
         >
-          <a>About us</a>
+          About us
         </Link>
       </li>
       <li>
@@ -172,9 +171,8 @@ function Home() {
             pathname: '/blog/[slug]',
             query: { slug: 'my-post' },
           }}
-          legacyBehavior
         >
-          <a>Blog Post</a>
+          Blog Post
         </Link>
       </li>
     </ul>
@@ -196,8 +194,8 @@ You can use every property as defined in the [Node.js URL module documentation](
 The default behavior of the `Link` component is to `push` a new URL into the `history` stack. You can use the `replace` prop to prevent adding a new entry, as in the following example:
 
 ```jsx
-<Link href="/about" replace legacyBehavior>
-  <a>About us</a>
+<Link href="/about" replace>
+  About us
 </Link>
 ```
 
@@ -206,8 +204,8 @@ The default behavior of the `Link` component is to `push` a new URL into the `hi
 The default behavior of `Link` is to scroll to the top of the page. When there is a hash defined it will scroll to the specific id, like a normal `<a>` tag. To prevent scrolling to the top / hash `scroll={false}` can be added to `Link`:
 
 ```jsx
-<Link href="/#hashid" scroll={false} legacyBehavior>
-  <a>Disables scrolling to the top</a>
+<Link href="/#hashid" scroll={false}>
+  Disables scrolling to the top
 </Link>
 ```
 

--- a/pages/docs/api-reference/next/link.mdx
+++ b/pages/docs/api-reference/next/link.mdx
@@ -31,17 +31,17 @@ function Home() {
   return (
     <ul>
       <li>
-        <Link href="/">
+        <Link href="/" legacyBehavior>
           <a>Home</a>
         </Link>
       </li>
       <li>
-        <Link href="/about">
+        <Link href="/about" legacyBehavior>
           <a>About Us</a>
         </Link>
       </li>
       <li>
-        <Link href="/blog/hello-world">
+        <Link href="/blog/hello-world" legacyBehavior>
           <a>Blog Post</a>
         </Link>
       </li>
@@ -77,7 +77,7 @@ function Posts({ posts }) {
     <ul>
       {posts.map((post) => (
         <li key={post.id}>
-          <Link href={`/blog/${encodeURIComponent(post.slug)}`}>
+          <Link href={`/blog/${encodeURIComponent(post.slug)}`} legacyBehavior>
             <a>{post.title}</a>
           </Link>
         </li>
@@ -161,6 +161,7 @@ function Home() {
             pathname: '/about',
             query: { name: 'test' },
           }}
+          legacyBehavior
         >
           <a>About us</a>
         </Link>
@@ -171,6 +172,7 @@ function Home() {
             pathname: '/blog/[slug]',
             query: { slug: 'my-post' },
           }}
+          legacyBehavior
         >
           <a>Blog Post</a>
         </Link>
@@ -194,7 +196,7 @@ You can use every property as defined in the [Node.js URL module documentation](
 The default behavior of the `Link` component is to `push` a new URL into the `history` stack. You can use the `replace` prop to prevent adding a new entry, as in the following example:
 
 ```jsx
-<Link href="/about" replace>
+<Link href="/about" replace legacyBehavior>
   <a>About us</a>
 </Link>
 ```
@@ -204,7 +206,7 @@ The default behavior of the `Link` component is to `push` a new URL into the `hi
 The default behavior of `Link` is to scroll to the top of the page. When there is a hash defined it will scroll to the specific id, like a normal `<a>` tag. To prevent scrolling to the top / hash `scroll={false}` can be added to `Link`:
 
 ```jsx
-<Link href="/#hashid" scroll={false}>
+<Link href="/#hashid" scroll={false} legacyBehavior>
   <a>Disables scrolling to the top</a>
 </Link>
 ```

--- a/pages/docs/api-reference/next/router.mdx
+++ b/pages/docs/api-reference/next/router.mdx
@@ -156,11 +156,11 @@ export default function Page(props) {
       <h1>Page: {router.query.slug}</h1>
       <p>Count: {count}</p>
       <button onClick={() => setCount(count + 1)}>Increase count</button>
-      <Link href="/one" legacyBehavior>
-        <a>one</a>
+      <Link href="/one">
+        one
       </Link>
-      <Link href="/two" legacyBehavior>
-        <a>two</a>
+      <Link href="/two">
+        two
       </Link>
     </div>
   )

--- a/pages/docs/api-reference/next/router.mdx
+++ b/pages/docs/api-reference/next/router.mdx
@@ -156,9 +156,10 @@ export default function Page(props) {
       <h1>Page: {router.query.slug}</h1>
       <p>Count: {count}</p>
       <button onClick={() => setCount(count + 1)}>Increase count</button>
-      <Link href="/one">
+      <Link href="/one" legacyBehavior>
         <a>one</a>
-      </Link> <Link href="/two">
+      </Link>
+      <Link href="/two" legacyBehavior>
         <a>two</a>
       </Link>
     </div>

--- a/pages/docs/migrating/from-gatsby.mdx
+++ b/pages/docs/migrating/from-gatsby.mdx
@@ -79,7 +79,7 @@ import Link from 'next/link'
 
 export default function Home() {
   return (
-    <Link href="/blog">
+    <Link href="/blog" legacyBehavior>
       <a>blog</a>
     </Link>
   )

--- a/pages/docs/migrating/from-gatsby.mdx
+++ b/pages/docs/migrating/from-gatsby.mdx
@@ -79,8 +79,8 @@ import Link from 'next/link'
 
 export default function Home() {
   return (
-    <Link href="/blog" legacyBehavior>
-      <a>blog</a>
+    <Link href="/blog">
+      blog
     </Link>
   )
 }

--- a/pages/docs/migrating/from-react-router.mdx
+++ b/pages/docs/migrating/from-react-router.mdx
@@ -33,7 +33,7 @@ import Link from 'next/link'
 
 export default function App() {
   return (
-    <Link href="/about">
+    <Link href="/about" legacyBehavior>
       <a>About</a>
     </Link>
   )

--- a/pages/docs/migrating/from-react-router.mdx
+++ b/pages/docs/migrating/from-react-router.mdx
@@ -33,8 +33,8 @@ import Link from 'next/link'
 
 export default function App() {
   return (
-    <Link href="/about" legacyBehavior>
-      <a>About</a>
+    <Link href="/about">
+      About
     </Link>
   )
 }

--- a/pages/docs/routing/dynamic-routes.mdx
+++ b/pages/docs/routing/dynamic-routes.mdx
@@ -59,18 +59,18 @@ function Home() {
   return (
     <ul>
       <li>
-        <Link href="/post/abc" legacyBehavior>
-          <a>Go to pages/post/[pid].js</a>
+        <Link href="/post/abc">
+          Go to pages/post/[pid].js
         </Link>
       </li>
       <li>
-        <Link href="/post/abc?foo=bar" legacyBehavior>
-          <a>Also goes to pages/post/[pid].js</a>
+        <Link href="/post/abc?foo=bar">
+          Also goes to pages/post/[pid].js
         </Link>
       </li>
       <li>
-        <Link href="/post/abc/a-comment" legacyBehavior>
-          <a>Go to pages/post/[pid]/[comment].js</a>
+        <Link href="/post/abc/a-comment">
+          Go to pages/post/[pid]/[comment].js
         </Link>
       </li>
     </ul>

--- a/pages/docs/routing/dynamic-routes.mdx
+++ b/pages/docs/routing/dynamic-routes.mdx
@@ -59,17 +59,17 @@ function Home() {
   return (
     <ul>
       <li>
-        <Link href="/post/abc">
+        <Link href="/post/abc" legacyBehavior>
           <a>Go to pages/post/[pid].js</a>
         </Link>
       </li>
       <li>
-        <Link href="/post/abc?foo=bar">
+        <Link href="/post/abc?foo=bar" legacyBehavior>
           <a>Also goes to pages/post/[pid].js</a>
         </Link>
       </li>
       <li>
-        <Link href="/post/abc/a-comment">
+        <Link href="/post/abc/a-comment" legacyBehavior>
           <a>Go to pages/post/[pid]/[comment].js</a>
         </Link>
       </li>

--- a/pages/docs/routing/introduction.mdx
+++ b/pages/docs/routing/introduction.mdx
@@ -43,18 +43,18 @@ function Home() {
   return (
     <ul>
       <li>
-        <Link href="/" legacyBehavior>
-          <a>Home</a>
+        <Link href="/">
+          Home
         </Link>
       </li>
       <li>
-        <Link href="/about" legacyBehavior>
-          <a>About Us</a>
+        <Link href="/about">
+          About Us
         </Link>
       </li>
       <li>
-        <Link href="/blog/hello-world" legacyBehavior>
-          <a>Blog Post</a>
+        <Link href="/blog/hello-world">
+          Blog Post
         </Link>
       </li>
     </ul>
@@ -84,8 +84,8 @@ function Posts({ posts }) {
     <ul>
       {posts.map((post) => (
         <li key={post.id}>
-          <Link href={`/blog/${encodeURIComponent(post.slug)}`} legacyBehavior>
-            <a>{post.title}</a>
+          <Link href={`/blog/${encodeURIComponent(post.slug)}`}>
+            {post.title}
           </Link>
         </li>
       ))}
@@ -113,9 +113,8 @@ function Posts({ posts }) {
               pathname: '/blog/[slug]',
               query: { slug: post.slug },
             }}
-            legacyBehavior
           >
-            <a>{post.title}</a>
+            {post.title}
           </Link>
         </li>
       ))}

--- a/pages/docs/routing/introduction.mdx
+++ b/pages/docs/routing/introduction.mdx
@@ -43,17 +43,17 @@ function Home() {
   return (
     <ul>
       <li>
-        <Link href="/">
+        <Link href="/" legacyBehavior>
           <a>Home</a>
         </Link>
       </li>
       <li>
-        <Link href="/about">
+        <Link href="/about" legacyBehavior>
           <a>About Us</a>
         </Link>
       </li>
       <li>
-        <Link href="/blog/hello-world">
+        <Link href="/blog/hello-world" legacyBehavior>
           <a>Blog Post</a>
         </Link>
       </li>
@@ -84,7 +84,7 @@ function Posts({ posts }) {
     <ul>
       {posts.map((post) => (
         <li key={post.id}>
-          <Link href={`/blog/${encodeURIComponent(post.slug)}`}>
+          <Link href={`/blog/${encodeURIComponent(post.slug)}`} legacyBehavior>
             <a>{post.title}</a>
           </Link>
         </li>
@@ -113,6 +113,7 @@ function Posts({ posts }) {
               pathname: '/blog/[slug]',
               query: { slug: post.slug },
             }}
+            legacyBehavior
           >
             <a>{post.title}</a>
           </Link>

--- a/pages/docs/testing.mdx
+++ b/pages/docs/testing.mdx
@@ -66,7 +66,7 @@ import Link from 'next/link'
 export default function Home() {
   return (
     <nav>
-      <Link href="/about">
+      <Link href="/about" legacyBehavior>
         <a>About</a>
       </Link>
     </nav>
@@ -183,7 +183,7 @@ import Link from 'next/link'
 export default function Home() {
   return (
     <nav>
-      <Link href="/about">
+      <Link href="/about" legacyBehavior>
         <a>About</a>
       </Link>
     </nav>

--- a/pages/docs/testing.mdx
+++ b/pages/docs/testing.mdx
@@ -66,8 +66,8 @@ import Link from 'next/link'
 export default function Home() {
   return (
     <nav>
-      <Link href="/about" legacyBehavior>
-        <a>About</a>
+      <Link href="/about">
+        About
       </Link>
     </nav>
   )
@@ -183,8 +183,8 @@ import Link from 'next/link'
 export default function Home() {
   return (
     <nav>
-      <Link href="/about" legacyBehavior>
-        <a>About</a>
+      <Link href="/about">
+        About
       </Link>
     </nav>
   )

--- a/pages/learn/basics/assets-metadata-css/layout-component.mdx
+++ b/pages/learn/basics/assets-metadata-css/layout-component.mdx
@@ -47,7 +47,7 @@ export default function FirstPost() {
       </Head>
       <h1>First Post</h1>
       <h2>
-        <Link href="/">
+        <Link href="/" legacyBehavior>
           <a>Back to home</a>
         </Link>
       </h2>

--- a/pages/learn/basics/assets-metadata-css/layout-component.mdx
+++ b/pages/learn/basics/assets-metadata-css/layout-component.mdx
@@ -47,8 +47,8 @@ export default function FirstPost() {
       </Head>
       <h1>First Post</h1>
       <h2>
-        <Link href="/" legacyBehavior>
-          <a>Back to home</a>
+        <Link href="/">
+          Back to home
         </Link>
       </h2>
     </Layout>

--- a/pages/learn/basics/assets-metadata-css/metadata.mdx
+++ b/pages/learn/basics/assets-metadata-css/metadata.mdx
@@ -58,7 +58,7 @@ export default function FirstPost() {
       </Head>
       <h1>First Post</h1>
       <h2>
-        <Link href="/">
+        <Link href="/" legacyBehavior>
           <a>Back to home</a>
         </Link>
       </h2>

--- a/pages/learn/basics/assets-metadata-css/metadata.mdx
+++ b/pages/learn/basics/assets-metadata-css/metadata.mdx
@@ -58,8 +58,8 @@ export default function FirstPost() {
       </Head>
       <h1>First Post</h1>
       <h2>
-        <Link href="/" legacyBehavior>
-          <a>Back to home</a>
+        <Link href="/">
+          Back to home
         </Link>
       </h2>
     </>

--- a/pages/learn/basics/assets-metadata-css/polishing-layout.mdx
+++ b/pages/learn/basics/assets-metadata-css/polishing-layout.mdx
@@ -152,17 +152,15 @@ export default function Layout({ children, home }) {
           </>
         ) : (
           <>
-            <Link href="/" legacyBehavior>
-              <a>
-                <Image
-                  priority
-                  src="/images/profile.jpg"
-                  className={utilStyles.borderCircle}
-                  height={108}
-                  width={108}
-                  alt=""
-                />
-              </a>
+            <Link href="/">
+              <Image
+                priority
+                src="/images/profile.jpg"
+                className={utilStyles.borderCircle}
+                height={108}
+                width={108}
+                alt=""
+              />
             </Link>
             <h2 className={utilStyles.headingLg}>
               <Link href="/">
@@ -175,8 +173,8 @@ export default function Layout({ children, home }) {
       <main>{children}</main>
       {!home && (
         <div className={styles.backToHome}>
-          <Link href="/" legacyBehavior>
-            <a>← 回到首頁</a>
+          <Link href="/">
+            ← 回到首頁
           </Link>
         </div>
       )}

--- a/pages/learn/basics/assets-metadata-css/polishing-layout.mdx
+++ b/pages/learn/basics/assets-metadata-css/polishing-layout.mdx
@@ -152,7 +152,7 @@ export default function Layout({ children, home }) {
           </>
         ) : (
           <>
-            <Link href="/">
+            <Link href="/" legacyBehavior>
               <a>
                 <Image
                   priority
@@ -175,7 +175,7 @@ export default function Layout({ children, home }) {
       <main>{children}</main>
       {!home && (
         <div className={styles.backToHome}>
-          <Link href="/">
+          <Link href="/" legacyBehavior>
             <a>← 回到首頁</a>
           </Link>
         </div>

--- a/pages/learn/basics/assets-metadata-css/third-party-javascript.mdx
+++ b/pages/learn/basics/assets-metadata-css/third-party-javascript.mdx
@@ -74,8 +74,8 @@ export default function FirstPost() {
       />
       <h1>First Post</h1>
       <h2>
-        <Link href="/" legacyBehavior>
-          <a>Back to home</a>
+        <Link href="/">
+          Back to home
         </Link>
       </h2>
     </>

--- a/pages/learn/basics/assets-metadata-css/third-party-javascript.mdx
+++ b/pages/learn/basics/assets-metadata-css/third-party-javascript.mdx
@@ -74,7 +74,7 @@ export default function FirstPost() {
       />
       <h1>First Post</h1>
       <h2>
-        <Link href="/">
+        <Link href="/" legacyBehavior>
           <a>Back to home</a>
         </Link>
       </h2>

--- a/pages/learn/basics/dynamic-routes/polishing-index-page.mdx
+++ b/pages/learn/basics/dynamic-routes/polishing-index-page.mdx
@@ -29,7 +29,7 @@
 
 ```html
   <li className={utilStyles.listItem} key={id}>
-    <Link href={`/posts/${id}`}>
+    <Link href={`/posts/${id}`} legacyBehavior>
       <a>{title}</a>
     </Link>
     <br />

--- a/pages/learn/basics/dynamic-routes/polishing-index-page.mdx
+++ b/pages/learn/basics/dynamic-routes/polishing-index-page.mdx
@@ -29,8 +29,8 @@
 
 ```html
   <li className={utilStyles.listItem} key={id}>
-    <Link href={`/posts/${id}`} legacyBehavior>
-      <a>{title}</a>
+    <Link href={`/posts/${id}`}>
+      {title}
     </Link>
     <br />
     <small className={utilStyles.lightText}>


### PR DESCRIPTION
When I using the <Link> tag with <a> in docs example, will get this error, so I add legacyBehavior in each <Link> to fix this error.

![CleanShot 2023-07-13 at 13 28 21](https://github.com/yuaanlin/nextjs.tw/assets/92412722/82467244-a2c5-4ab9-8f59-94155f68ba2b)

![CleanShot 2023-07-13 at 13 29 13](https://github.com/yuaanlin/nextjs.tw/assets/92412722/544bcb3d-2970-4577-b7c7-6039b57f6acd)
